### PR TITLE
Update injectdeps.js

### DIFF
--- a/injectdeps.js
+++ b/injectdeps.js
@@ -71,7 +71,7 @@ Container.prototype.bindName = function(name) {
         case 'string':
         case 'number':
         case 'boolean': {
-          this.available[name] = new InnerConstructor([], () => ''+val);
+          this.available[name] = new InnerConstructor([], () => val);
         } break;
 
         default: {


### PR DESCRIPTION
Unnecessary type conversion returned all config values as strings regardless of the type specified in the config